### PR TITLE
Remove attachment layout

### DIFF
--- a/examples/hello_cube/hello_cube.cpp
+++ b/examples/hello_cube/hello_cube.cpp
@@ -238,7 +238,7 @@ void HelloCube::Update(const WindowState& window) {
                      TextureTransition{
                          .texture    = m_depth_texture,
                          .old_layout = loon::gpu::Layout::DontCare,
-                         .new_layout = Layout::Attachment,
+                         .new_layout = Layout::General,
                      });
     gpu::cmd_begin_render_pass(cmd, {
                                    .color_attachments = RenderAttachment{

--- a/examples/many_cubes/many_cubes.cpp
+++ b/examples/many_cubes/many_cubes.cpp
@@ -301,7 +301,7 @@ void ManyCubes::Update(const WindowState& window) {
                      TextureTransition{
                          .texture    = m_depth_texture,
                          .old_layout = Layout::DontCare,
-                         .new_layout = Layout::Attachment,
+                         .new_layout = Layout::General,
                      });
 
     gpu::cmd_begin_render_pass(cmd,{

--- a/examples/particle_emitter/particle_emitter.cpp
+++ b/examples/particle_emitter/particle_emitter.cpp
@@ -297,7 +297,7 @@ void ParticleEmitter::Update(const WindowState& window) {
                      TextureTransition{
                          .texture    = m_depth_texture,
                          .old_layout = Layout::DontCare,
-                         .new_layout = Layout::Attachment,
+                         .new_layout = Layout::General,
                      });
 
     gpu::cmd_begin_render_pass(cmd,{

--- a/examples/textured_cube/textured_cube.cpp
+++ b/examples/textured_cube/textured_cube.cpp
@@ -273,7 +273,7 @@ void TexturedCube::Update(const WindowState& window) {
                      TextureTransition{
                          .texture    = m_depth_texture,
                          .old_layout = loon::gpu::Layout::DontCare,
-                         .new_layout = Layout::Attachment,
+                         .new_layout = Layout::General,
                      });
     gpu::cmd_begin_render_pass(cmd,{
                                    .color_attachments = RenderAttachment{

--- a/include/gpu/loon_gpu.h
+++ b/include/gpu/loon_gpu.h
@@ -537,7 +537,6 @@ LOON_DEFINE_BITWISE_OPS(StageFlags);
 enum class Layout : uint8_t {
     DontCare = 0,
     General,
-    Attachment,
 };
 
 enum class HazardFlags : uint8_t {

--- a/src/vk/gpu_to_vk.cpp
+++ b/src/vk/gpu_to_vk.cpp
@@ -405,7 +405,6 @@ VkImageLayout bridge(Layout layout) {
     switch (layout) {
         case Layout::DontCare: return VK_IMAGE_LAYOUT_UNDEFINED;
         case Layout::General: return VK_IMAGE_LAYOUT_GENERAL;
-        case Layout::Attachment: return VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
     }
     return VK_IMAGE_LAYOUT_MAX_ENUM;
 }

--- a/src/vk/loon_gpu.cpp
+++ b/src/vk/loon_gpu.cpp
@@ -2972,7 +2972,7 @@ void cmd_begin_render_pass(CommandBuffer cmd, RenderPassDesc desc) {
             .sType              = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
             .pNext              = nullptr,
             .imageView          = impl->m_texture_pool[attachment.texture].default_image_view,
-            .imageLayout        = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL,
+            .imageLayout        = VK_IMAGE_LAYOUT_GENERAL,
             .resolveMode        = VK_RESOLVE_MODE_NONE,  // TODO: Multisampling support
             .resolveImageView   = VK_NULL_HANDLE,
             .resolveImageLayout = VK_IMAGE_LAYOUT_GENERAL,
@@ -2991,7 +2991,7 @@ void cmd_begin_render_pass(CommandBuffer cmd, RenderPassDesc desc) {
             .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
             .pNext = nullptr,
             .imageView = impl->m_texture_pool[desc.depth_attachment.texture].default_image_view,
-            .imageLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL,
+            .imageLayout = VK_IMAGE_LAYOUT_GENERAL,
             .resolveMode = VK_RESOLVE_MODE_NONE,
             .resolveImageView = VK_NULL_HANDLE,
             .resolveImageLayout = VK_IMAGE_LAYOUT_GENERAL,
@@ -3165,7 +3165,7 @@ void cmd_wait_for_surface_texture(CommandBuffer cmd) {
         .dstStageMask     = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
         .dstAccessMask    = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_2_SHADER_WRITE_BIT,
         .oldLayout        = VK_IMAGE_LAYOUT_UNDEFINED,
-        .newLayout        = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL, // TODO: this wouldn't work for shader writing, should switch to general layout instead. 
+        .newLayout        = VK_IMAGE_LAYOUT_GENERAL,
         .image            = impl->m_texture_pool[current_image].vk_image,
         .subresourceRange = VkImageSubresourceRange{
             .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
@@ -3208,7 +3208,7 @@ void cmd_signal_surface_texture(CommandBuffer cmd) {
         .srcAccessMask    = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_2_SHADER_WRITE_BIT,
         .dstStageMask     = VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT,
         .dstAccessMask    = 0,
-        .oldLayout        = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL,
+        .oldLayout        = VK_IMAGE_LAYOUT_GENERAL,
         .newLayout        = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
         .image            = impl->m_texture_pool[current_image].vk_image,
         .subresourceRange = VkImageSubresourceRange{


### PR DESCRIPTION
Next step in removing explicit image transitions. This may break some compression stuff on certain hardware, but doesn't seem like it for newer HW, and no difference on apple.  