### PR TITLE
Replace chrono and memory stl headers with our implementations.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Split some of these into a separate library so we can write some unit tests
 # for them
-add_library(example_utilities OBJECT common/geometry.cpp common/filesystem.cpp)
+add_library(example_utilities OBJECT common/geometry.cpp common/filesystem.cpp
+  common/timer.cpp)
 
 target_include_directories(example_utilities
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common)

--- a/examples/common/box.h
+++ b/examples/common/box.h
@@ -1,0 +1,68 @@
+#pragma once
+#include <cstddef>
+
+namespace loon {
+
+template <class T>
+struct DefaultDeleter {
+    void operator()(T* ptr) { delete ptr; }
+};
+
+template <class T, class Deleter = DefaultDeleter<T>>
+class Box {
+   public:
+    constexpr Box() noexcept = default;
+    constexpr Box(std::nullptr_t) noexcept {};
+    constexpr explicit Box(T* ptr) noexcept : m_ptr(ptr) {};
+    constexpr Box(const Box<T>& other) = delete;
+    constexpr Box(Box<T>&& other) noexcept : m_ptr(other.release()) {}
+
+    template <class U>
+    constexpr Box(Box<U>&& other) noexcept : m_ptr(other.release()) {}
+
+    ~Box() {
+        if (m_ptr) { get_deleter()(m_ptr); }
+    }
+
+    constexpr Box& operator=(Box&& other) noexcept {
+        T* ptr      = other.m_ptr;
+        other.m_ptr = m_ptr;
+        m_ptr       = ptr;
+        return *this;
+    }
+    constexpr Box& operator=(const Box&) = delete;
+
+    // Modifiers
+
+    constexpr T* release() noexcept {
+        T* ptr = m_ptr;
+        m_ptr  = nullptr;
+        return ptr;
+    }
+
+    constexpr void reset(T* ptr = nullptr) noexcept {
+        if (m_ptr) { get_deleter()(m_ptr); }
+        m_ptr = ptr;
+    }
+
+    // Observers
+
+    constexpr T*             get() const noexcept { return m_ptr; }
+    constexpr Deleter&       get_deleter() noexcept { return m_deleter; }
+    constexpr const Deleter& get_deleter() const noexcept { return m_deleter; }
+    explicit                 operator bool() const noexcept { return m_ptr != nullptr; }
+
+    constexpr T& operator*() const noexcept { return *m_ptr; }
+    constexpr T* operator->() const noexcept { return m_ptr; }
+
+   private:
+    T*                            m_ptr = nullptr;
+    [[no_unique_address]] Deleter m_deleter;
+};
+
+template <class T, class... Args>
+Box<T> make_box(Args&&... args) {
+    return Box<T>(new T(static_cast<Args&&>(args)...));
+}
+
+}  // namespace loon

--- a/examples/common/example.cpp
+++ b/examples/common/example.cpp
@@ -14,9 +14,9 @@ extern "C" __declspec(dllimport) unsigned long __stdcall GetModuleFileNameA(void
 #    include <unistd.h>
 #endif
 
-#include <memory>
 #include <vector>
 
+#include "common/box.h"
 #include "hello_cube/hello_cube.h"
 #include "hello_triangle/hello_triangle.h"
 #include "many_cubes/many_cubes.h"
@@ -76,13 +76,13 @@ void log_callback(loon::gpu::LogLevel lvl, loon::gpu::Span<const char> message, 
     fprintf(stderr, "%.*s\n", static_cast<int>(message.size()), message.data());
 }
 
-std::unique_ptr<Example> create_example(ExampleName name, const WindowState& state) {
+loon::Box<Example> create_example(ExampleName name, const WindowState& state) {
     switch (name) {
-        case ExampleName::HelloTriangle: return std::make_unique<HelloTriangle>(state);
-        case ExampleName::HelloCube: return std::make_unique<HelloCube>(state);
-        case ExampleName::TexturedCube: return std::make_unique<TexturedCube>(state);
-        case ExampleName::ParticleEmitter: return std::make_unique<ParticleEmitter>(state);
-        case ExampleName::ManyCubes: return std::make_unique<ManyCubes>(state);
+        case ExampleName::HelloTriangle: return loon::make_box<HelloTriangle>(state);
+        case ExampleName::HelloCube: return loon::make_box<HelloCube>(state);
+        case ExampleName::TexturedCube: return loon::make_box<TexturedCube>(state);
+        case ExampleName::ParticleEmitter: return loon::make_box<ParticleEmitter>(state);
+        case ExampleName::ManyCubes: return loon::make_box<ManyCubes>(state);
         default: return nullptr;
     }
 }

--- a/examples/common/example.h
+++ b/examples/common/example.h
@@ -2,8 +2,9 @@
 
 #include <gpu/loon_gpu.h>
 
-#include <memory>
 #include <string>
+
+#include "common/box.h"
 
 
 class ShaderLoader;
@@ -14,12 +15,12 @@ struct FilePaths {
 };
 
 struct WindowState {
-    uintptr_t                     native_window_handle;
-    uintptr_t                     native_instance_handle;
-    uint16_t                      width;
-    uint16_t                      height;
-    std::unique_ptr<ShaderLoader> shader_loader;
-    FilePaths                     file_paths;
+    uintptr_t               native_window_handle;
+    uintptr_t               native_instance_handle;
+    uint16_t                width;
+    uint16_t                height;
+    loon::Box<ShaderLoader> shader_loader;
+    FilePaths               file_paths;
 };
 
 class Example {
@@ -42,4 +43,4 @@ FilePaths default_file_paths();
 
 void log_callback(loon::gpu::LogLevel lvl, loon::gpu::Span<const char> message, void* userdata);
 
-std::unique_ptr<Example> create_example(ExampleName name, const WindowState& state);
+loon::Box<Example> create_example(ExampleName name, const WindowState& state);

--- a/examples/common/example_macos.mm
+++ b/examples/common/example_macos.mm
@@ -9,17 +9,17 @@
 #import <Metal/Metal.h>
 #import <MetalKit/MetalKit.h>
 
+#import "common/box.h"
 #import "common/example.h"
 #import "common/shaders.h"
 #import "imgui/imgui_impl_osx.h"
-#import <memory>
 #import <string>
 
 // MAKE: AppViewController
 
 @interface AppViewController : NSViewController <NSWindowDelegate> {
   WindowState window_state;
-  std::unique_ptr<Example> current_example;
+  loon::Box<Example> current_example;
   ExampleName selected_example;
 }
 @end
@@ -43,7 +43,7 @@
         .native_instance_handle = 0,
         .width = 1200,
         .height = 800,
-        .shader_loader = std::make_unique<ShaderLoader>(
+        .shader_loader = loon::make_box<ShaderLoader>(
             file_paths.shader_directory.c_str(),
             loon::gpu::device_backend() == loon::gpu::Backend::Metal),
         .file_paths = file_paths,

--- a/examples/common/example_win32.cpp
+++ b/examples/common/example_win32.cpp
@@ -5,11 +5,11 @@
 #include <shellapi.h>
 
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "common/box.h"
 #include "common/example.h"
 #include "common/shaders.h"
 #include "imgui/imgui_impl_win32.h"
@@ -116,7 +116,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
     }
 
     window_state.shader_loader
-        = std::make_unique<ShaderLoader>(window_state.file_paths.shader_directory.c_str());
+        = loon::make_box<ShaderLoader>(window_state.file_paths.shader_directory.c_str());
 
     const char  CLASS_NAME[] = "LoonWebGPU Examples";
     WNDCLASSEXA wc           = {.cbSize        = sizeof(WNDCLASSEXA),
@@ -169,7 +169,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 
     ExampleName selected_example = ExampleName::ManyCubes;
 
-    std::unique_ptr<Example> current_example = create_example(selected_example, window_state);
+    loon::Box<Example> current_example = create_example(selected_example, window_state);
 
     RawInput input;
 

--- a/examples/common/shaders.cpp
+++ b/examples/common/shaders.cpp
@@ -181,7 +181,7 @@ class ShaderLoader::Impl {
 };
 
 ShaderLoader::ShaderLoader(std::string_view search_path, bool use_metal) {
-    m_impl = std::make_unique<Impl>(search_path, use_metal);
+    m_impl = loon::make_box<Impl>(search_path, use_metal);
 }
 
 ShaderLoader::~ShaderLoader() = default;

--- a/examples/common/shaders.h
+++ b/examples/common/shaders.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 

--- a/examples/common/shaders.h
+++ b/examples/common/shaders.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <string_view>
 #include <vector>
 

--- a/examples/common/shaders.h
+++ b/examples/common/shaders.h
@@ -4,6 +4,7 @@
 #include <string_view>
 #include <vector>
 
+#include "common/box.h"
 
 namespace slang {
 struct TypeLayoutReflection;
@@ -13,7 +14,7 @@ struct ShaderModuleImpl;
 struct ShaderModuleDeleter {
     void operator()(ShaderModuleImpl* ptr);
 };
-using ShaderModule = std::unique_ptr<ShaderModuleImpl, ShaderModuleDeleter>;
+using ShaderModule = loon::Box<ShaderModuleImpl, ShaderModuleDeleter>;
 
 std::vector<uint8_t> get_spirv(ShaderModuleImpl* module, const char* entry_point);
 
@@ -28,5 +29,5 @@ class ShaderLoader {
 
    private:
     class Impl;
-    std::unique_ptr<Impl> m_impl;
+    loon::Box<Impl> m_impl;
 };

--- a/examples/common/timer.cpp
+++ b/examples/common/timer.cpp
@@ -1,7 +1,5 @@
 #include "timer.h"
 
-#include <_time.h>
-
 #if _WIN32
 extern "C" {
 __declspec(dllimport) bool __stdcall QueryPerformanceCounter(int64_t* lpPerformanceCount);
@@ -34,7 +32,8 @@ static uint64_t current_time_ns() {
 static uint64_t current_time_ns() {
     timespec result;
     clock_gettime(CLOCK_MONOTONIC, &result);
-    return static_cast<uint64_t>(result.tv_sec) * 1'000'000'000ull + static_cast<uint64_t>(tv_nsec);
+    return static_cast<uint64_t>(result.tv_sec) * 1'000'000'000ull
+           + static_cast<uint64_t>(result.tv_nsec);
 }
 
 #endif

--- a/examples/common/timer.cpp
+++ b/examples/common/timer.cpp
@@ -16,7 +16,7 @@ static uint64_t current_time_ns() {
     int64_t qpc = 0;
     QueryPerformanceCounter(&qpc);
 
-    return static_cast<uint64_t>(qpc * 1'000'000'000 / freq);
+    return static_cast<uint64_t>(qpc * 1'000'000'000 / qpc_frequency);
 }
 
 #elif __APPLE__

--- a/examples/common/timer.cpp
+++ b/examples/common/timer.cpp
@@ -1,0 +1,57 @@
+#include "timer.h"
+
+#include <_time.h>
+
+#if _WIN32
+extern "C" {
+__declspec(dllimport) bool __stdcall QueryPerformanceCounter(int64_t* lpPerformanceCount);
+__declspec(dllimport) bool __stdcall QueryPerformanceFrequency(int64_t* lpFreq);
+}
+
+static uint64_t current_time_ns() {
+    static const int64_t qpc_frequency = []() {
+        int64_t freq = 1;
+        QueryPerformanceFrequency(&freq);
+        return freq;
+    }();
+
+    int64_t qpc = 0;
+    QueryPerformanceCounter(&qpc);
+
+    return static_cast<uint64_t>(qpc * 1'000'000'000 / freq);
+}
+
+#elif __APPLE__
+#    include <time.h>
+
+static uint64_t current_time_ns() {
+    return clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+}
+
+#elif __linux__
+
+#    include <time.h>
+static uint64_t current_time_ns() {
+    timespec result;
+    clock_gettime(CLOCK_MONOTONIC, &result);
+    return static_cast<uint64_t>(result.tv_sec) * 1'000'000'000ull + static_cast<uint64_t>(tv_nsec);
+}
+
+#endif
+
+namespace loon {
+
+Instant Instant::now() noexcept {
+    return Instant(current_time_ns());
+};
+
+Duration Instant::duration_since(Instant earlier) const noexcept {
+    return Duration(m_nanoseconds - earlier.m_nanoseconds);
+}
+
+Duration Instant::elapsed() const noexcept {
+    Instant n = Instant::now();
+    return n.duration_since(*this);
+}
+
+}  // namespace loon

--- a/examples/common/timer.h
+++ b/examples/common/timer.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <cstdint>
+
+namespace loon {
+
+class Instant;
+class Duration;
+
+class Duration {
+   public:
+    constexpr Duration(uint64_t nanoseconds) noexcept : m_nanoseconds(nanoseconds) {};
+
+    uint64_t as_nanoseconds() const noexcept { return m_nanoseconds; };
+    uint64_t as_microseconds() const noexcept { return m_nanoseconds / 1'000; }
+    uint64_t as_milliseconds() const noexcept { return m_nanoseconds / 1'000'000; };
+
+    float as_millseconds_f32() const noexcept {
+        return static_cast<float>(m_nanoseconds) / 1'000'000.f;
+    }
+
+   private:
+    uint64_t m_nanoseconds = 0;
+};
+
+class Instant {
+   public:
+    Instant()                          = delete;
+    Instant(const Instant&)            = default;
+    Instant& operator=(const Instant&) = default;
+
+    static Instant now() noexcept;
+    Duration       duration_since(Instant earlier) const noexcept;
+    Duration       elapsed() const noexcept;
+
+   private:
+    Instant(uint64_t ns) : m_nanoseconds(ns) {}
+    uint64_t m_nanoseconds;
+};
+
+}  // namespace loon

--- a/examples/many_cubes/many_cubes.cpp
+++ b/examples/many_cubes/many_cubes.cpp
@@ -3,11 +3,11 @@
 #include <gpu/loon_gpu.h>
 
 #include <cassert>
-#include <chrono>
 #include <cstring>
 
 #include "common/geometry.h"
 #include "common/shaders.h"
+#include "common/timer.h"
 #include "imgui/imgui.h"
 #include "imgui/imgui_impl_loon.h"
 #include "stb_image.h"
@@ -283,7 +283,7 @@ void ManyCubes::Update(const WindowState& window) {
         return;
     }
 
-    auto frame_start = std::chrono::high_resolution_clock::now();
+    auto frame_start = loon::Instant::now();
     auto cmd         = gpu::queue_start_command_recording(m_queue);
 
     gpu::cmd_wait_for_surface_texture(cmd);
@@ -397,12 +397,9 @@ void ManyCubes::Update(const WindowState& window) {
     gpu::cmd_finalize(cmd);
     gpu::queue_submit(m_queue, cmd);
 
-
-    auto                            frame_end = std::chrono::high_resolution_clock::now();
-    const std::chrono::microseconds diff
-        = std::chrono::duration_cast<std::chrono::microseconds>(frame_end - frame_start);
-    m_frame_time_us[m_frame_idx % 300] = diff.count();
-    m_frame_time_ms[m_frame_idx % 300] = diff.count() / 1000.f;
+    auto frame_duration                = frame_start.elapsed();
+    m_frame_time_us[m_frame_idx % 300] = (int64_t)frame_duration.as_microseconds();
+    m_frame_time_ms[m_frame_idx % 300] = frame_duration.as_millseconds_f32();
 
     m_frame_time_average
         += (m_frame_time_us[m_frame_idx % 300] - m_frame_time_us[(m_frame_idx + 1) % 300]) / 300;


### PR DESCRIPTION
A significant percentage of total compile time on windows was from including chrono and memory headers. These should be the last heavy headers to reduce windows compile time, and were easy to replace - having a unique_ptr replacement and an easy way to time code is nice.