### PR TITLE
Bugfix: (VK backend) incorrect specialization constant offsets

### DIFF
--- a/src/vk/loon_gpu.cpp
+++ b/src/vk/loon_gpu.cpp
@@ -1995,6 +1995,7 @@ static VkSpecializationInfo construct_specialization_info(
                                  .offset     = offset,
                                  .size       = size,
                              });
+        offset += size;
     }
 
     return VkSpecializationInfo{


### PR DESCRIPTION
The `offset` counter in `construct_specialization_info` doesn't actually increment. So when there is more than one specialisation constants the offsets are actually incorrect.

As proof of bug: I changed `hello_triangle.slang` to:
```slang
[vk::constant_id(0)] float red;
[vk::constant_id(1)] float green;
[vk::constant_id(2)] float blue;

// ...

[shader("vertex")]
VertexStageOutput vertex_main(uint32_t vertexIdx : SV_VertexID)
{
    const float2 verts[3] = {float2(0, 0.5), float2(0.5, -0.5), float2(-0.5,-0.5)};
    const float2 uv = verts[vertexIdx % 3];
    const float4 p = float4(uv, 0.5 , 1);
    CoarseVertex vert_out;
    vert_out.color = {red, green, blue}; // changed here
    VertexStageOutput output = {p, vert_out};
    return output;
}

// ...
```

and then in `hello_triangle.cpp`:
```cxx
    // line 62
    SpecializationConstant spec_constants[3] = {
        SpecializationConstant {
            .constant_id = 0,
            .float_val = 0.1,
            .type = SpecializationConstantType::Float32,
        },
        SpecializationConstant {
            .constant_id = 1,
            .float_val = 0.8,
            .type = SpecializationConstantType::Float32,
        },
        SpecializationConstant {
            .constant_id = 2,
            .float_val = 1.0,
            .type = SpecializationConstantType::Float32,
        },
    };

    m_render_pipeline = gpu::create_graphics_pipeline(
        m_device,
        {
            .source      = Span(vertex_spirv.data(), vertex_spirv.size()).as_bytes(),
            .entry_point = "vertex_main"_sv,
        },
        {
            .source      = Span(fragment_spirv.data(), fragment_spirv.size()).as_bytes(),
            .entry_point = "fragment_main"_sv,
        },
        RasterDesc{.color_targets = {{.format = m_swapchain_format}}},
        spec_constants);
```

the result: (left after, right before)
<img width="49%" alt="Screenshot 2026-05-11 at 14 20 52" src="https://github.com/user-attachments/assets/447e857f-6ff9-40d8-af97-34124751b6a7" /><img width="49%" alt="Screenshot 2026-05-11 at 14 21 16" src="https://github.com/user-attachments/assets/2a49b4e2-f7c6-4d41-9427-50d4adbfdbcc" />
