### PR TITLE
Add some additional warnings and fix unused variable/argument warnings

### DIFF
--- a/.github/workflows/cmake-build-and-test.yml
+++ b/.github/workflows/cmake-build-and-test.yml
@@ -78,6 +78,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DLOON_GPU_BUILD_TESTS=YES
         -DLOON_GPU_BUILD_EXAMPLES=YES
+        -DOON_GPU_WERROR=YES
         -S ${{ github.workspace }}
         -G "Ninja Multi-Config"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if(LOON_GPU_WERROR)
   if(MSVC)
     target_compile_options(loon_gpu PRIVATE /WX)
   else()
-    target_compile_options(loon_gpu PRIVATE -Werror)
+    target_compile_options(loon_gpu PRIVATE -Werror -Wall -Wunused-parameter)
   endif()
 endif()
 

--- a/src/mtl/loon_gpu.cpp
+++ b/src/mtl/loon_gpu.cpp
@@ -397,6 +397,7 @@ void device_wait_for_idle(Device d) {
 
 // MARK: Surface functions
 SurfaceCapabilities get_surface_capabilities(Device d) {
+    (void)d;
     return SurfaceCapabilities{
         .usages  = UsageFlags::ColorAttachment | UsageFlags::TransferDst | UsageFlags::Storage,
         .formats = Surface::kSwapchainFormats,
@@ -444,6 +445,7 @@ SurfaceTextureInfo get_current_texture(Device d) {
 }
 
 SurfaceStatus present(Device d, Queue queue) {
+    (void)queue;
     d->surface.current_drawable->present();
     d->surface.current_drawable = nullptr;
     d->texture_pool.erase(d->surface.current_texture);
@@ -457,6 +459,7 @@ GpuPtr malloc(Device d, size_t bytes, Memory memory) {
 }
 
 GpuPtr malloc(Device d, size_t bytes, size_t align, Memory memory) {
+    (void)align;  // TODO: Can we do alignment on MTL? Do we need to?
     id<MTL::HeapDescriptor> heap_info = make_id<MTL::HeapDescriptor>();
     heap_info->setType(MTL::HeapTypePlacement);
     heap_info->setStorageMode(memory == Memory::Gpu ? MTL::StorageModePrivate
@@ -762,9 +765,7 @@ Handle<Pipeline> create_compute_pipeline(Device                             d,
         return {};
     }
 
-    const auto metadata = parse_metadata(*get_thread_local_arena(d),
-                                         compute.source.cast<const char>(),
-                                         compute.entry_point);
+    const auto metadata = parse_metadata(compute.source.cast<const char>(), compute.entry_point);
 
     return d->pipeline_pool.emplace({
         .render_pipeline  = nullptr,
@@ -1009,6 +1010,7 @@ static CommandBufferImpl* get_command_buffer(Queue q, CommandPool* pool) {
 }
 
 Queue get_queue(Device d, QueueType type) {
+    (void)type;  // TODO: Support multiple queues.
     if (!d->queue.command_queue) {
         d->queue = {
             .command_queue  = NS::TransferPtr(d->device->newMTL4CommandQueue()),
@@ -1075,7 +1077,10 @@ void queue_submit(Queue                     q,
     if (signal_drawable) { q->command_queue->signalDrawable(d->surface.current_drawable.get()); }
 }
 
-void queue_cancel(Queue q, Span<const Handle<CommandBuffer>> command_buffers) {}
+void queue_cancel(Queue q, Span<const Handle<CommandBuffer>> command_buffers) {
+    (void)q;
+    (void)command_buffers;
+}
 
 void queue_on_submitted_work_completed(Queue q, Function<void>&& fn) {
     q->pending_events.emplace_back(
@@ -1196,6 +1201,8 @@ void cmd_copy_from_texture(CommandBuffer                cmd,
 
 void cmd_set_texture_heap(CommandBuffer cmd, Handle<TextureHeap> heap) {
     // This is currently a NOOP since all textures are in the global residency set.
+    (void)cmd;
+    (void)heap;
 }
 
 void cmd_barrier(CommandBuffer cmd, StageFlags before, StageFlags after) {
@@ -1447,6 +1454,7 @@ void cmd_draw_indexed_instanced_indirect_multi(CommandBuffer                cmd,
         cmd->device,
         false,
         "gpu::cmd_draw_indexed_instanced_indirect_multi: Multidraw not supported on metal.");
+    (void)args;
 }
 
 void cmd_wait_for_surface_texture(CommandBuffer cmd) {

--- a/src/mtl/metal_compute_metadata.cpp
+++ b/src/mtl/metal_compute_metadata.cpp
@@ -20,9 +20,7 @@ static Dimension3D parse_dim(std::string_view str) {
 
 // TODO: This is super hacky, need better testing around it.
 // Would like to not need it at all, but what can ya do.
-ShaderMetadata parse_metadata(Arena            arena,
-                              Span<const char> metal_source,
-                              Span<const char> entry_point) {
+ShaderMetadata parse_metadata(Span<const char> metal_source, Span<const char> entry_point) {
     // First, look for a copy of "entry_point", then go backwards to see if it's preceeded by
     // "void" - this is the kernel definition.
     const std::string_view source(metal_source.begin(), metal_source.end());

--- a/src/mtl/metal_compute_metadata.h
+++ b/src/mtl/metal_compute_metadata.h
@@ -9,8 +9,6 @@ struct ShaderMetadata {
     Dimension3D required_threadgroup_size;
 };
 
-ShaderMetadata parse_metadata(Arena            arena,
-                              Span<const char> metal_source,
-                              Span<const char> entry_point);
+ShaderMetadata parse_metadata(Span<const char> metal_source, Span<const char> entry_point);
 
 }  // namespace loon::gpu

--- a/src/vk/loon_gpu.cpp
+++ b/src/vk/loon_gpu.cpp
@@ -909,7 +909,6 @@ static FeaturesAndExtensions get_supported_features(
 }
 
 static LogicalDeviceCreateResult create_logical_device(
-    const DeviceDesc&         desc,
     Arena                     arena,
     const PhysicalDeviceInfo& physical_device_info) {
     float                         queue_priority = 1.0f;
@@ -1051,7 +1050,7 @@ Device create_device(const DeviceDesc& desc) {
     VkDevice       logical_device = VK_NULL_HANDLE;
     DeviceFeatures features{};
     if (result == VK_SUCCESS) {
-        auto l         = create_logical_device(desc, init_arena, physical_device_info);
+        auto l         = create_logical_device(init_arena, physical_device_info);
         result         = l.result;
         logical_device = l.logical_device;
         features       = l.features;
@@ -1541,8 +1540,6 @@ SurfaceTextureInfo get_current_texture(Device d) {
 }
 
 SurfaceStatus present(Device d, Queue q) {
-    auto presenting_texture_handle = d->surface.swapchain_images[d->surface.current_image_idx];
-
     auto s = d->semaphore_pool[d->surface.present_semaphores[d->surface.current_image_idx]];
     VkPresentInfoKHR present_info{
         .sType              = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
@@ -2455,12 +2452,12 @@ Queue get_queue(Device d, QueueType type) {
 
 // MARK: Sempahores
 
-Handle<Semaphore> create_semaphore(Device d, uint64_t initValue) {
+Handle<Semaphore> create_semaphore(Device d, uint64_t init_value) {
     VkSemaphoreTypeCreateInfo semaphore_type{
         .sType         = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO,
         .pNext         = nullptr,
         .semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE,
-        .initialValue  = 0,
+        .initialValue  = init_value,
     };
 
     VkSemaphoreCreateInfo timeline_create_info{
@@ -2821,7 +2818,10 @@ void queue_submit(Queue                     q,
     d->api.vkQueueSubmit2(q->queue, 1, &submit_info, VK_NULL_HANDLE);
 }
 
-void queue_cancel(Queue q, Span<const Handle<CommandBuffer>> commandBuffers) {}
+void queue_cancel(Queue q, Span<const Handle<CommandBuffer>> command_buffers) {
+    (void)q;
+    (void)command_buffers;
+}
 
 void queue_on_submitted_work_completed(Queue q, Function<void>&& fn) {
     q->pending_events.emplace_back(

--- a/src/vk/vma_usage.h
+++ b/src/vk/vma_usage.h
@@ -2,6 +2,9 @@
 #ifdef __clang__
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wnullability-completeness"
+#    pragma clang diagnostic ignored "-Wunused-variable"
+#    pragma clang diagnostic ignored "-Wunused-private-field"
+#    pragma clang diagnostic ignored "-Wunused-parameter"
 #endif
 #include "volk.h"
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
There were a few unused variable/unused argument warnings that at least in one case were hiding a bug in the vulkan backend. Fix the bug as found by @johan0A in #26 and make sure that I can catch them in the future.