### PR TITLE
Examples refactor - move some setup code into the shared example files

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-VULKAN_SDK="/Users/kevin/VulkanSDK/1.4.341.1/macOS"
-VK_ICD_FILENAMES="/Users/kevin/VulkanSDK/1.4.341.1/macOS/share/vulkan/icd.d/MoltenVK_icd.json"
-VK_DRIVER_FILES="/Users/kevin/VulkanSDK/1.4.341.1/macOS/share/vulkan/icd.d/MoltenVK_icd.json"

--- a/examples/common/example.cpp
+++ b/examples/common/example.cpp
@@ -129,7 +129,7 @@ Example::~Example() {
     gpu::destroy_device(m_device);
 }
 
-void Example::Tick(const WindowState& window) {
+void Example::tick(const WindowState& window) {
     auto surface_texture = gpu::get_current_texture(m_device);
     if (surface_texture.status == SurfaceStatus::OutOfDate ||
         surface_texture.status == SurfaceStatus::Suboptimal) {
@@ -139,7 +139,7 @@ void Example::Tick(const WindowState& window) {
         return;
     }
 
-    this->Update({
+    this->update({
         .color_format  = m_swapchain_format,
         .depth_format  = m_depth_format,
         .color_texture = surface_texture.texture,

--- a/examples/common/example.cpp
+++ b/examples/common/example.cpp
@@ -144,6 +144,11 @@ void Example::Tick(const WindowState& window) {
         .depth_format  = m_depth_format,
         .color_texture = surface_texture.texture,
         .depth_texture = m_depth_texture,
+        .texture_size =
+            {
+                .x = m_swapchain_width,
+                .y = m_swapchain_height,
+            },
     });
 
     const auto status = gpu::present(m_device, m_queue);

--- a/examples/common/example.cpp
+++ b/examples/common/example.cpp
@@ -1,5 +1,7 @@
 #include "example.h"
 
+#include <gpu/loon_gpu.h>
+
 #include "filesystem.h"
 
 #define STB_IMAGE_IMPLEMENTATION
@@ -89,4 +91,88 @@ loon::Box<Example> create_example(ExampleName name, const WindowState& state) {
         case ExampleName::ManyCubes: return loon::make_box<ManyCubes>(state);
         default: return nullptr;
     }
+}
+
+using namespace loon;
+
+static Format select_surface_format(const loon::gpu::SurfaceCapabilities& surface_capabilities) {
+    for (Format f : surface_capabilities.formats) {
+        if (f == loon::gpu::Format::RGBA8UnormSrgb || f == loon::gpu::Format::BGRA8UnormSrgb) {
+            // Choose 8 bit srgb if we have it
+            return f;
+        }
+    }
+    return surface_capabilities.formats[0];
+}
+
+Example::Example(const WindowState& window) {
+    m_device = loon::gpu::create_device({
+        .gpu_preference         = loon::gpu::GpuPreference::Discrete,
+        .native_window_handle   = window.native_window_handle,
+        .native_instance_handle = window.native_instance_handle,
+        .log_callback           = log_callback,
+        .log_userdata           = nullptr,
+        .log_level              = LogLevel::Debug,
+        .alloc_callback         = nullptr,
+        .alloc_userdata         = nullptr,
+    });
+
+    auto surface_capabilities = gpu::get_surface_capabilities(m_device);
+    m_swapchain_format        = select_surface_format(surface_capabilities);
+
+    recreate_swapchain(window.width, window.height);
+
+    m_queue = gpu::get_queue(m_device);
+}
+
+Example::~Example() {
+    gpu::destroy_device(m_device);
+}
+
+void Example::Tick(const WindowState& window) {
+    auto surface_texture = gpu::get_current_texture(m_device);
+    if (surface_texture.status == SurfaceStatus::OutOfDate ||
+        surface_texture.status == SurfaceStatus::Suboptimal) {
+        recreate_swapchain(window.width, window.height);
+        return;
+    } else if (surface_texture.status == SurfaceStatus::Error) {
+        return;
+    }
+
+    this->Update({
+        .color_format  = m_swapchain_format,
+        .depth_format  = m_depth_format,
+        .color_texture = surface_texture.texture,
+        .depth_texture = m_depth_texture,
+    });
+
+    const auto status = gpu::present(m_device, m_queue);
+    if (status == SurfaceStatus::OutOfDate || status == SurfaceStatus::Suboptimal) {
+        recreate_swapchain(window.width, window.height);
+    }
+}
+
+void Example::recreate_swapchain(uint32_t width, uint32_t height) {
+    gpu::unconfigure_surface(m_device);
+    gpu::configure_surface(m_device,
+                           {
+                               .format       = m_swapchain_format,
+                               .usages       = loon::gpu::UsageFlags::ColorAttachment,
+                               .width        = width,
+                               .height       = height,
+                               .present_mode = PresentMode::Fifo,
+                           });
+    m_swapchain_width  = width;
+    m_swapchain_height = height;
+
+    // Recreate depth buffer as well
+    if (m_depth_texture) { gpu::free(m_device, m_depth_texture); }
+    m_depth_texture =
+        gpu::create_texture(m_device,
+                            {
+                                .type       = TextureType::Tex2D,
+                                .dimensions = {.x = width, .y = height, .z = 1},
+                                .format     = m_depth_format,
+                                .usage      = loon::gpu::UsageFlags::DepthStencilAttachment,
+                            });
 }

--- a/examples/common/example.h
+++ b/examples/common/example.h
@@ -25,8 +25,32 @@ struct WindowState {
 
 class Example {
    public:
-    virtual ~Example() {};
-    virtual void Update(const WindowState& window) = 0;
+    Example(const WindowState& window_state);
+    virtual ~Example();
+    void Tick(const WindowState& window);
+
+   protected:
+    struct UpdateInfo {
+        loon::gpu::Format                     color_format;
+        loon::gpu::Format                     depth_format;
+        loon::gpu::Handle<loon::gpu::Texture> color_texture;
+        loon::gpu::Handle<loon::gpu::Texture> depth_texture;
+    };
+
+    virtual bool Update(const UpdateInfo& info) = 0;
+
+    loon::gpu::Device m_device;
+    loon::gpu::Queue  m_queue;
+    loon::gpu::Format m_swapchain_format;
+    uint32_t          m_swapchain_width;
+    uint32_t          m_swapchain_height;
+
+   private:
+    void recreate_swapchain(uint32_t width, uint32_t height);
+
+    loon::gpu::Format m_depth_format = loon::gpu::Format::Depth32Float;
+
+    loon::gpu::Handle<loon::gpu::Texture> m_depth_texture;
 };
 
 enum class ExampleName {

--- a/examples/common/example.h
+++ b/examples/common/example.h
@@ -35,6 +35,7 @@ class Example {
         loon::gpu::Format                     depth_format;
         loon::gpu::Handle<loon::gpu::Texture> color_texture;
         loon::gpu::Handle<loon::gpu::Texture> depth_texture;
+        loon::gpu::Dimension2D                texture_size;
     };
 
     virtual bool Update(const UpdateInfo& info) = 0;
@@ -42,12 +43,11 @@ class Example {
     loon::gpu::Device m_device;
     loon::gpu::Queue  m_queue;
     loon::gpu::Format m_swapchain_format;
-    uint32_t          m_swapchain_width;
-    uint32_t          m_swapchain_height;
 
    private:
-    void recreate_swapchain(uint32_t width, uint32_t height);
-
+    void              recreate_swapchain(uint32_t width, uint32_t height);
+    uint32_t          m_swapchain_width;
+    uint32_t          m_swapchain_height;
     loon::gpu::Format m_depth_format = loon::gpu::Format::Depth32Float;
 
     loon::gpu::Handle<loon::gpu::Texture> m_depth_texture;

--- a/examples/common/example.h
+++ b/examples/common/example.h
@@ -27,7 +27,7 @@ class Example {
    public:
     Example(const WindowState& window_state);
     virtual ~Example();
-    void Tick(const WindowState& window);
+    void tick(const WindowState& window);
 
    protected:
     struct UpdateInfo {
@@ -38,18 +38,18 @@ class Example {
         loon::gpu::Dimension2D                texture_size;
     };
 
-    virtual bool Update(const UpdateInfo& info) = 0;
+    virtual bool update(const UpdateInfo& info) = 0;
 
     loon::gpu::Device m_device;
     loon::gpu::Queue  m_queue;
     loon::gpu::Format m_swapchain_format;
 
    private:
-    void              recreate_swapchain(uint32_t width, uint32_t height);
-    uint32_t          m_swapchain_width;
-    uint32_t          m_swapchain_height;
-    loon::gpu::Format m_depth_format = loon::gpu::Format::Depth32Float;
+    void recreate_swapchain(uint32_t width, uint32_t height);
 
+    loon::gpu::Format                     m_depth_format = loon::gpu::Format::Depth32Float;
+    uint32_t                              m_swapchain_width;
+    uint32_t                              m_swapchain_height;
     loon::gpu::Handle<loon::gpu::Texture> m_depth_texture;
 };
 

--- a/examples/common/example_macos.mm
+++ b/examples/common/example_macos.mm
@@ -58,7 +58,7 @@
 
     ImGui::StyleColorsDark();
 
-    self->selected_example = ExampleName::HelloCube;
+    self->selected_example = ExampleName::HelloTriangle;
   }
 
   return self;
@@ -99,7 +99,7 @@
   }
 
   ImGui_ImplOSX_NewFrame(self.view);
-  current_example->Update(self->window_state);
+  current_example->Tick(self->window_state);
 }
 
 - (void)mtkView:(MTKView *)view drawableSizeWillChange:(CGSize)size {

--- a/examples/common/example_macos.mm
+++ b/examples/common/example_macos.mm
@@ -99,7 +99,7 @@
   }
 
   ImGui_ImplOSX_NewFrame(self.view);
-  current_example->Tick(self->window_state);
+  current_example->tick(self->window_state);
 }
 
 - (void)mtkView:(MTKView *)view drawableSizeWillChange:(CGSize)size {

--- a/examples/common/example_win32.cpp
+++ b/examples/common/example_win32.cpp
@@ -213,7 +213,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
             current_example  = create_example(selected_example, window_state);
         }
 
-        current_example->Update(window_state);
+        current_example->tick(window_state);
     }
 
     ImGui_ImplWin32_Shutdown();

--- a/examples/hello_cube/hello_cube.cpp
+++ b/examples/hello_cube/hello_cube.cpp
@@ -140,8 +140,8 @@ bool HelloCube::Update(const UpdateInfo& info) {
     // Update constant data
     auto args = reinterpret_cast<ShaderArgs*>(gpu::get_host_pointer(m_device, m_constant_buffer));
     args[m_frame_idx % 3].camera = CameraInfo{
-        .projection        = projection({.view_width  = (float)m_swapchain_width,
-                                         .view_height = (float)m_swapchain_height,
+        .projection        = projection({.view_width  = (float)info.texture_size.x,
+                                         .view_height = (float)info.texture_size.y,
                                          .y_fov       = radians_from_degrees(30.f),
                                          .depth_far   = 0.5f}),
         .camera_from_world = transform3d::identity().translated({0, 0, -5}).to_matrix(),
@@ -158,25 +158,28 @@ bool HelloCube::Update(const UpdateInfo& info) {
     auto cmd = gpu::queue_start_command_recording(m_queue);
     gpu::cmd_wait_for_surface_texture(cmd);
     gpu::cmd_barrier(cmd, StageFlags::FragmentTests, StageFlags::FragmentTests);
-    gpu::cmd_begin_render_pass(
-        cmd,
-        {
-            .color_attachments =
-                RenderAttachment{
-                    .texture     = info.color_texture,
-                    .load_op     = loon::gpu::LoadOp::Clear,
-                    .store_op    = loon::gpu::StoreOp::Store,
-                    .clear_color = Color(0, 0, 0, 0),
-                },
-            .depth_attachment =
-                RenderAttachment{
-                    .texture     = info.depth_texture,
-                    .load_op     = loon::gpu::LoadOp::Clear,
-                    .store_op    = loon::gpu::StoreOp::Discard,
-                    .clear_color = Color(0, 0, 0, 0),
-                },
-            .render_area = {.width = m_swapchain_width, .height = m_swapchain_height},
-        });
+    gpu::cmd_begin_render_pass(cmd,
+                               {
+                                   .color_attachments =
+                                       RenderAttachment{
+                                           .texture     = info.color_texture,
+                                           .load_op     = loon::gpu::LoadOp::Clear,
+                                           .store_op    = loon::gpu::StoreOp::Store,
+                                           .clear_color = Color(0, 0, 0, 0),
+                                       },
+                                   .depth_attachment =
+                                       RenderAttachment{
+                                           .texture     = info.depth_texture,
+                                           .load_op     = loon::gpu::LoadOp::Clear,
+                                           .store_op    = loon::gpu::StoreOp::Discard,
+                                           .clear_color = Color(0, 0, 0, 0),
+                                       },
+                                   .render_area =
+                                       {
+                                           .width  = info.texture_size.x,
+                                           .height = info.texture_size.y,
+                                       },
+                               });
     gpu::cmd_set_depth_stencil_state(cmd, m_depth_stencil_state);
     gpu::cmd_set_pipeline(cmd, m_render_pipeline);
     gpu::cmd_draw_indexed_instanced(

--- a/examples/hello_cube/hello_cube.cpp
+++ b/examples/hello_cube/hello_cube.cpp
@@ -136,7 +136,7 @@ HelloCube::HelloCube(const WindowState& window_state) : Example(window_state) {
         });
 }
 
-bool HelloCube::Update(const UpdateInfo& info) {
+bool HelloCube::update(const UpdateInfo& info) {
     // Update constant data
     auto args = reinterpret_cast<ShaderArgs*>(gpu::get_host_pointer(m_device, m_constant_buffer));
     args[m_frame_idx % 3].camera = CameraInfo{

--- a/examples/hello_cube/hello_cube.cpp
+++ b/examples/hello_cube/hello_cube.cpp
@@ -16,6 +16,7 @@
 
 #include "common/geometry.h"
 #include "common/shaders.h"
+#include "example.h"
 using namespace geometry;
 using namespace loon;
 namespace {
@@ -80,32 +81,7 @@ static Format select_surface_format(const loon::gpu::SurfaceCapabilities& surfac
     return surface_capabilities.formats[0];
 }
 
-HelloCube::HelloCube(const WindowState& window_state) {
-    m_device = gpu::create_device({
-        .gpu_preference         = GpuPreference::Discrete,
-        .native_window_handle   = window_state.native_window_handle,
-        .native_instance_handle = window_state.native_instance_handle,
-        .log_callback           = log_callback,
-        .log_userdata           = nullptr,
-        .log_level              = LogLevel::Debug,
-        .alloc_callback         = nullptr,
-        .alloc_userdata         = nullptr,
-    });
-
-    auto surface_capabilities = gpu::get_surface_capabilities(m_device);
-    m_swapchain_format        = select_surface_format(surface_capabilities);
-
-    gpu::configure_surface(m_device,
-                           {
-                               .format       = m_swapchain_format,
-                               .usages       = loon::gpu::UsageFlags::ColorAttachment,
-                               .width        = window_state.width,
-                               .height       = window_state.height,
-                               .present_mode = PresentMode::Fifo,
-                           });
-    m_swapchain_width  = window_state.width;
-    m_swapchain_height = window_state.height;
-
+HelloCube::HelloCube(const WindowState& window_state) : Example(window_state) {
     // Load shaders and create render pipeline
     ShaderModule shader         = window_state.shader_loader->load_module("hello_cube");
     const auto   vertex_spirv   = get_spirv(shader.get(), "vertex_main");
@@ -127,8 +103,6 @@ HelloCube::HelloCube(const WindowState& window_state) {
         });
 
     assert(m_render_pipeline.h != 0);
-
-    m_queue = gpu::get_queue(m_device);
 
     m_vertex_ptr = gpu::malloc(m_device, Cube::kSize, Memory::Gpu);
 
@@ -153,16 +127,7 @@ HelloCube::HelloCube(const WindowState& window_state) {
     gpu::wait_semaphore(m_device, copy_semaphore, 1);
     gpu::free(m_device, copy_semaphore);
 
-    // Create a depth texture
-    m_depth_texture = gpu::create_texture(
-        m_device,
-        {
-            .type       = TextureType::Tex2D,
-            .dimensions = {.x = window_state.width, .y = window_state.height, .z = 1},
-            .format     = loon::gpu::Format::Depth32Float,
-            .usage      = loon::gpu::UsageFlags::DepthStencilAttachment,
-        });
-
+    // Create a depth state
     m_depth_stencil_state = gpu::create_depth_stencil_state(
         m_device,
         DepthStencilDesc{
@@ -171,43 +136,12 @@ HelloCube::HelloCube(const WindowState& window_state) {
         });
 }
 
-HelloCube::~HelloCube() {
-    destroy_device(m_device);
-}
-
-void HelloCube::recreate_swapchain(uint32_t width, uint32_t height) {
-    gpu::device_wait_for_idle(m_device);
-    gpu::unconfigure_surface(m_device);
-    gpu::configure_surface(m_device,
-                           {
-                               .format       = m_swapchain_format,
-                               .usages       = loon::gpu::UsageFlags::ColorAttachment,
-                               .width        = width,
-                               .height       = height,
-                               .present_mode = PresentMode::Fifo,
-                           });
-    m_swapchain_width  = width;
-    m_swapchain_height = height;
-
-    // Recreate depth buffer as well
-
-    gpu::free(m_device, m_depth_texture);
-    m_depth_texture =
-        gpu::create_texture(m_device,
-                            {
-                                .type       = TextureType::Tex2D,
-                                .dimensions = {.x = width, .y = height, .z = 1},
-                                .format     = loon::gpu::Format::Depth32Float,
-                                .usage      = loon::gpu::UsageFlags::DepthStencilAttachment,
-                            });
-}
-
-void HelloCube::Update(const WindowState& window) {
+bool HelloCube::Update(const UpdateInfo& info) {
     // Update constant data
     auto args = reinterpret_cast<ShaderArgs*>(gpu::get_host_pointer(m_device, m_constant_buffer));
     args[m_frame_idx % 3].camera = CameraInfo{
-        .projection        = projection({.view_width  = (float)window.width,
-                                         .view_height = (float)window.height,
+        .projection        = projection({.view_width  = (float)m_swapchain_width,
+                                         .view_height = (float)m_swapchain_height,
                                          .y_fov       = radians_from_degrees(30.f),
                                          .depth_far   = 0.5f}),
         .camera_from_world = transform3d::identity().translated({0, 0, -5}).to_matrix(),
@@ -221,15 +155,6 @@ void HelloCube::Update(const WindowState& window) {
                                .to_matrix(),
     };
 
-    auto surface_texture = gpu::get_current_texture(m_device);
-    if (surface_texture.status == SurfaceStatus::OutOfDate ||
-        surface_texture.status == SurfaceStatus::Suboptimal) {
-        recreate_swapchain(window.width, window.height);
-        return;
-    } else if (surface_texture.status == SurfaceStatus::Error) {
-        return;
-    }
-
     auto cmd = gpu::queue_start_command_recording(m_queue);
     gpu::cmd_wait_for_surface_texture(cmd);
     gpu::cmd_barrier(cmd, StageFlags::FragmentTests, StageFlags::FragmentTests);
@@ -238,14 +163,14 @@ void HelloCube::Update(const WindowState& window) {
         {
             .color_attachments =
                 RenderAttachment{
-                    .texture     = surface_texture.texture,
+                    .texture     = info.color_texture,
                     .load_op     = loon::gpu::LoadOp::Clear,
                     .store_op    = loon::gpu::StoreOp::Store,
                     .clear_color = Color(0, 0, 0, 0),
                 },
             .depth_attachment =
                 RenderAttachment{
-                    .texture     = m_depth_texture,
+                    .texture     = info.depth_texture,
                     .load_op     = loon::gpu::LoadOp::Clear,
                     .store_op    = loon::gpu::StoreOp::Discard,
                     .clear_color = Color(0, 0, 0, 0),
@@ -268,11 +193,6 @@ void HelloCube::Update(const WindowState& window) {
     gpu::cmd_finalize(cmd);
     gpu::queue_submit(m_queue, cmd);
 
-    const auto status = gpu::present(m_device, m_queue);
-    if (status == SurfaceStatus::OutOfDate || status == SurfaceStatus::Suboptimal) {
-        recreate_swapchain(window.width, window.height);
-    }
-
-    gpu::queue_process_events(m_queue);
     ++m_frame_idx;
+    return true;
 }

--- a/examples/hello_cube/hello_cube.h
+++ b/examples/hello_cube/hello_cube.h
@@ -11,7 +11,7 @@ class HelloCube : public Example {
     ~HelloCube() override = default;
 
    private:
-    bool Update(const UpdateInfo& info) override;
+    bool update(const UpdateInfo& info) override;
 
     Handle<Pipeline> m_render_pipeline;
     uint64_t         m_frame_idx = 0;

--- a/examples/hello_cube/hello_cube.h
+++ b/examples/hello_cube/hello_cube.h
@@ -8,23 +8,16 @@ using namespace loon::gpu;
 class HelloCube : public Example {
    public:
     HelloCube(const WindowState& window_state);
-    ~HelloCube() override;
-    void Update(const WindowState& window) override;
+    ~HelloCube() override = default;
 
    private:
-    void recreate_swapchain(uint32_t width, uint32_t height);
+    bool Update(const UpdateInfo& info) override;
 
-    Device           m_device;
-    Queue            m_queue;
-    Format           m_swapchain_format;
     Handle<Pipeline> m_render_pipeline;
-    uint64_t         m_frame_idx        = 0;
-    uint32_t         m_swapchain_width  = 0;
-    uint32_t         m_swapchain_height = 0;
+    uint64_t         m_frame_idx = 0;
 
     GpuPtr m_vertex_ptr;
 
     GpuPtr                    m_constant_buffer;
-    Handle<Texture>           m_depth_texture;
     Handle<DepthStencilState> m_depth_stencil_state;
 };

--- a/examples/hello_triangle/hello_triangle.cpp
+++ b/examples/hello_triangle/hello_triangle.cpp
@@ -38,7 +38,7 @@ HelloTriangle::HelloTriangle(const WindowState& window_state) : Example(window_s
     assert(m_render_pipeline.h != 0);
 }
 
-bool HelloTriangle::Update(const UpdateInfo& info) {
+bool HelloTriangle::update(const UpdateInfo& info) {
     auto cmd = gpu::queue_start_command_recording(m_queue);
 
     gpu::cmd_wait_for_surface_texture(cmd);

--- a/examples/hello_triangle/hello_triangle.cpp
+++ b/examples/hello_triangle/hello_triangle.cpp
@@ -17,42 +17,7 @@
 
 using namespace loon;
 
-static Format select_surface_format(const loon::gpu::SurfaceCapabilities& surface_capabilities) {
-    for (Format f : surface_capabilities.formats) {
-        if (f == loon::gpu::Format::RGBA8UnormSrgb || f == loon::gpu::Format::BGRA8UnormSrgb) {
-            // Choose 8 bit srgb if we have it
-            return f;
-        }
-    }
-    return surface_capabilities.formats[0];
-}
-
-HelloTriangle::HelloTriangle(const WindowState& window_state) {
-    m_device = loon::gpu::create_device({
-        .gpu_preference         = loon::gpu::GpuPreference::Discrete,
-        .native_window_handle   = window_state.native_window_handle,
-        .native_instance_handle = window_state.native_instance_handle,
-        .log_callback           = log_callback,
-        .log_userdata           = nullptr,
-        .log_level              = LogLevel::Debug,
-        .alloc_callback         = nullptr,
-        .alloc_userdata         = nullptr,
-    });
-
-    auto surface_capabilities = gpu::get_surface_capabilities(m_device);
-    m_swapchain_format        = select_surface_format(surface_capabilities);
-
-    gpu::configure_surface(m_device,
-                           {
-                               .format       = m_swapchain_format,
-                               .usages       = loon::gpu::UsageFlags::ColorAttachment,
-                               .width        = window_state.width,
-                               .height       = window_state.height,
-                               .present_mode = PresentMode::Fifo,
-                           });
-    m_swapchain_width  = window_state.width;
-    m_swapchain_height = window_state.height;
-
+HelloTriangle::HelloTriangle(const WindowState& window_state) : Example(window_state) {
     // Load shaders and create render pipeline
     ShaderModule shader         = window_state.shader_loader->load_module("hello_triangle");
     const auto   vertex_spirv   = get_spirv(shader.get(), "vertex_main");
@@ -71,38 +36,9 @@ HelloTriangle::HelloTriangle(const WindowState& window_state) {
         RasterDesc{.color_targets = {{.format = m_swapchain_format}}});
 
     assert(m_render_pipeline.h != 0);
-
-    m_queue = gpu::get_queue(m_device);
 }
 
-HelloTriangle::~HelloTriangle() {
-    destroy_device(m_device);
-}
-
-void HelloTriangle::recreate_swapchain(uint32_t width, uint32_t height) {
-    gpu::unconfigure_surface(m_device);
-    gpu::configure_surface(m_device,
-                           {
-                               .format       = m_swapchain_format,
-                               .usages       = loon::gpu::UsageFlags::ColorAttachment,
-                               .width        = width,
-                               .height       = height,
-                               .present_mode = PresentMode::Fifo,
-                           });
-    m_swapchain_width  = width;
-    m_swapchain_height = height;
-}
-
-void HelloTriangle::Update(const WindowState& window) {
-    auto surface_texture = gpu::get_current_texture(m_device);
-    if (surface_texture.status == SurfaceStatus::OutOfDate ||
-        surface_texture.status == SurfaceStatus::Suboptimal) {
-        recreate_swapchain(window.width, window.height);
-        return;
-    } else if (surface_texture.status == SurfaceStatus::Error) {
-        return;
-    }
-
+bool HelloTriangle::Update(const UpdateInfo& info) {
     auto cmd = gpu::queue_start_command_recording(m_queue);
 
     gpu::cmd_wait_for_surface_texture(cmd);
@@ -110,7 +46,7 @@ void HelloTriangle::Update(const WindowState& window) {
                                {
                                    .color_attachments =
                                        RenderAttachment{
-                                           .texture     = surface_texture.texture,
+                                           .texture     = info.color_texture,
                                            .load_op     = loon::gpu::LoadOp::Clear,
                                            .store_op    = loon::gpu::StoreOp::Store,
                                            .clear_color = Color(0, 0, 0, 0),
@@ -131,8 +67,5 @@ void HelloTriangle::Update(const WindowState& window) {
 
     gpu::queue_submit(m_queue, cmd);
 
-    const auto status = gpu::present(m_device, m_queue);
-    if (status == SurfaceStatus::OutOfDate || status == SurfaceStatus::Suboptimal) {
-        recreate_swapchain(window.width, window.height);
-    }
+    return true;
 }

--- a/examples/hello_triangle/hello_triangle.cpp
+++ b/examples/hello_triangle/hello_triangle.cpp
@@ -53,8 +53,8 @@ bool HelloTriangle::Update(const UpdateInfo& info) {
                                        },
                                    .render_area =
                                        Rect2D{
-                                           .width  = m_swapchain_width,
-                                           .height = m_swapchain_height,
+                                           .width  = info.texture_size.x,
+                                           .height = info.texture_size.y,
                                        },
                                });
 

--- a/examples/hello_triangle/hello_triangle.h
+++ b/examples/hello_triangle/hello_triangle.h
@@ -11,7 +11,7 @@ class HelloTriangle : public Example {
     ~HelloTriangle() override = default;
 
    protected:
-    bool Update(const UpdateInfo& window) override;
+    bool update(const UpdateInfo& window) override;
 
    private:
     Handle<Pipeline> m_render_pipeline;

--- a/examples/hello_triangle/hello_triangle.h
+++ b/examples/hello_triangle/hello_triangle.h
@@ -8,15 +8,11 @@ using namespace loon::gpu;
 class HelloTriangle : public Example {
    public:
     HelloTriangle(const WindowState& window_state);
-    ~HelloTriangle() override;
-    void Update(const WindowState& window) override;
+    ~HelloTriangle() override = default;
+
+   protected:
+    bool Update(const UpdateInfo& window) override;
 
    private:
-    void             recreate_swapchain(uint32_t width, uint32_t height);
-    Device           m_device;
-    Queue            m_queue;
-    Format           m_swapchain_format;
     Handle<Pipeline> m_render_pipeline;
-    uint32_t         m_swapchain_width  = 0;
-    uint32_t         m_swapchain_height = 0;
 };

--- a/examples/many_cubes/many_cubes.cpp
+++ b/examples/many_cubes/many_cubes.cpp
@@ -80,20 +80,19 @@ ManyCubes::ManyCubes(const WindowState& window_state) : Example(window_state) {
     ShaderModule shader         = window_state.shader_loader->load_module("many_cubes");
     const auto   vertex_spirv   = get_spirv(shader.get(), "vertex_main");
     const auto   fragment_spirv = get_spirv(shader.get(), "fragment_main");
-
-    m_render_pipeline = gpu::create_graphics_pipeline(
+    m_render_pipeline           = gpu::create_graphics_pipeline(
         m_device,
         {
-            .source      = Span(vertex_spirv.data(), vertex_spirv.size()).as_bytes(),
-            .entry_point = "vertex_main"_sv,
+                      .source      = Span(vertex_spirv.data(), vertex_spirv.size()).as_bytes(),
+                      .entry_point = "vertex_main"_sv,
         },
         {
-            .source      = Span(fragment_spirv.data(), fragment_spirv.size()).as_bytes(),
-            .entry_point = "fragment_main"_sv,
+                      .source      = Span(fragment_spirv.data(), fragment_spirv.size()).as_bytes(),
+                      .entry_point = "fragment_main"_sv,
         },
         RasterDesc{
-            .depth_format  = loon::gpu::Format::Depth32Float,
-            .color_targets = {{.format = m_swapchain_format}},
+                      .depth_format  = loon::gpu::Format::Depth32Float,
+                      .color_targets = {{.format = m_swapchain_format}},
         });
 
     assert(m_render_pipeline.h != 0);
@@ -183,7 +182,7 @@ ManyCubes::~ManyCubes() {
 }
 
 
-bool ManyCubes::Update(const UpdateInfo& info) {
+bool ManyCubes::update(const UpdateInfo& info) {
     // Imgui:
 
     loon::imgui::NewFrame();

--- a/examples/many_cubes/many_cubes.cpp
+++ b/examples/many_cubes/many_cubes.cpp
@@ -210,8 +210,8 @@ bool ManyCubes::Update(const UpdateInfo& info) {
     GpuPtr camera = m_ring_buffer.append(
         m_frame_idx,
         CameraData{
-            .projection        = geometry::projection({.view_width  = (float)m_swapchain_width,
-                                                       .view_height = (float)m_swapchain_height,
+            .projection        = geometry::projection({.view_width  = (float)info.texture_size.x,
+                                                       .view_height = (float)info.texture_size.y,
                                                        .y_fov       = geometry::radians_from_degrees(30.f),
                                                        .depth_far   = 0.5f}),
             .camera_from_world = geometry::transform3d::identity()
@@ -253,8 +253,8 @@ bool ManyCubes::Update(const UpdateInfo& info) {
                                        },
                                    .render_area =
                                        {
-                                           .width  = m_swapchain_width,
-                                           .height = m_swapchain_height,
+                                           .width  = info.texture_size.x,
+                                           .height = info.texture_size.y,
                                        },
                                });
     gpu::cmd_set_front_face(cmd, FrontFace::CW);

--- a/examples/many_cubes/many_cubes.cpp
+++ b/examples/many_cubes/many_cubes.cpp
@@ -75,23 +75,7 @@ static Format select_surface_format(const loon::gpu::SurfaceCapabilities& surfac
     return surface_capabilities.formats[0];
 }
 
-ManyCubes::ManyCubes(const WindowState& window_state) {
-    m_device = loon::gpu::create_device({
-        .gpu_preference         = GpuPreference::Discrete,
-        .native_window_handle   = window_state.native_window_handle,
-        .native_instance_handle = window_state.native_instance_handle,
-        .log_callback           = log_callback,
-        .log_userdata           = nullptr,
-        .log_level              = LogLevel::Debug,
-        .alloc_callback         = nullptr,
-        .alloc_userdata         = nullptr,
-    });
-
-    auto surface_capabilities = gpu::get_surface_capabilities(m_device);
-    m_swapchain_format        = select_surface_format(surface_capabilities);
-
-    recreate_swapchain(window_state.width, window_state.height);
-
+ManyCubes::ManyCubes(const WindowState& window_state) : Example(window_state) {
     // Load shaders and create render pipeline
     ShaderModule shader         = window_state.shader_loader->load_module("many_cubes");
     const auto   vertex_spirv   = get_spirv(shader.get(), "vertex_main");
@@ -113,8 +97,6 @@ ManyCubes::ManyCubes(const WindowState& window_state) {
         });
 
     assert(m_render_pipeline.h != 0);
-
-    m_queue = gpu::get_queue(m_device);
 
     m_vertex_ptr = gpu::malloc(m_device, Cube::kSize, Memory::Gpu);
 
@@ -198,37 +180,10 @@ ManyCubes::ManyCubes(const WindowState& window_state) {
 ManyCubes::~ManyCubes() {
     gpu::device_wait_for_idle(m_device);
     loon::imgui::Shutdown();
-    m_ring_buffer = RingBuffer();
-    destroy_device(m_device);
 }
 
-void ManyCubes::recreate_swapchain(uint32_t width, uint32_t height) {
-    gpu::device_wait_for_idle(m_device);
-    gpu::unconfigure_surface(m_device);
-    gpu::configure_surface(m_device,
-                           {
-                               .format       = m_swapchain_format,
-                               .usages       = loon::gpu::UsageFlags::ColorAttachment,
-                               .width        = width,
-                               .height       = height,
-                               .present_mode = PresentMode::Fifo,
-                           });
-    m_swapchain_width  = width;
-    m_swapchain_height = height;
 
-    // Recreate depth buffer as well
-    if (m_depth_texture.h) { gpu::free(m_device, m_depth_texture); }
-    m_depth_texture =
-        gpu::create_texture(m_device,
-                            {
-                                .type       = TextureType::Tex2D,
-                                .dimensions = {.x = width, .y = height, .z = 1},
-                                .format     = loon::gpu::Format::Depth32Float,
-                                .usage      = loon::gpu::UsageFlags::DepthStencilAttachment,
-                            });
-}
-
-void ManyCubes::Update(const WindowState& window) {
+bool ManyCubes::Update(const UpdateInfo& info) {
     // Imgui:
 
     loon::imgui::NewFrame();
@@ -251,14 +206,12 @@ void ManyCubes::Update(const WindowState& window) {
     ImGui::End();
     m_frame_idx++;
 
-
-
     // Set up global draw arguments, these are constant for all cubes drawn.
     GpuPtr camera = m_ring_buffer.append(
         m_frame_idx,
         CameraData{
-            .projection        = geometry::projection({.view_width  = (float)window.width,
-                                                       .view_height = (float)window.height,
+            .projection        = geometry::projection({.view_width  = (float)m_swapchain_width,
+                                                       .view_height = (float)m_swapchain_height,
                                                        .y_fov       = geometry::radians_from_degrees(30.f),
                                                        .depth_far   = 0.5f}),
             .camera_from_world = geometry::transform3d::identity()
@@ -274,14 +227,6 @@ void ManyCubes::Update(const WindowState& window) {
                                        });
 
     // Render
-    auto surface_texture = gpu::get_current_texture(m_device);
-    if (surface_texture.status == SurfaceStatus::OutOfDate ||
-        surface_texture.status == SurfaceStatus::Suboptimal) {
-        recreate_swapchain(window.width, window.height);
-        return;
-    } else if (surface_texture.status == SurfaceStatus::Error) {
-        return;
-    }
 
     auto frame_start = loon::Instant::now();
     auto cmd         = gpu::queue_start_command_recording(m_queue);
@@ -294,14 +239,14 @@ void ManyCubes::Update(const WindowState& window) {
                                {
                                    .color_attachments =
                                        RenderAttachment{
-                                           .texture     = surface_texture.texture,
+                                           .texture     = info.color_texture,
                                            .load_op     = LoadOp::Clear,
                                            .store_op    = StoreOp::Store,
                                            .clear_color = Color(0, 0, 0, 0),
                                        },
                                    .depth_attachment =
                                        RenderAttachment{
-                                           .texture     = m_depth_texture,
+                                           .texture     = info.depth_texture,
                                            .load_op     = LoadOp::Clear,
                                            .store_op    = StoreOp::Discard,
                                            .clear_color = Color(0, 0, 0, 0),
@@ -397,7 +342,6 @@ void ManyCubes::Update(const WindowState& window) {
         }
     }
 
-
     loon::imgui::Render(cmd);
     gpu::cmd_end_render_pass(cmd);
     gpu::cmd_signal_surface_texture(cmd);
@@ -410,10 +354,5 @@ void ManyCubes::Update(const WindowState& window) {
 
     m_frame_time_average +=
         (m_frame_time_us[m_frame_idx % 300] - m_frame_time_us[(m_frame_idx + 1) % 300]) / 300;
-
-    const auto status = gpu::present(m_device, m_queue);
-    if (status == SurfaceStatus::OutOfDate || status == SurfaceStatus::Suboptimal) {
-        recreate_swapchain(window.width, window.height);
-    }
-    gpu::queue_process_events(m_queue);
+    return true;
 }

--- a/examples/many_cubes/many_cubes.h
+++ b/examples/many_cubes/many_cubes.h
@@ -13,20 +13,11 @@ class ManyCubes : public Example {
     ManyCubes(const WindowState& window_state);
     ~ManyCubes() override;
 
-    void Update(const WindowState& window) override;
+    bool Update(const UpdateInfo& window) override;
 
    private:
-    void recreate_swapchain(uint32_t width, uint32_t height);
-
-    Device   m_device;
-    Queue    m_queue;
-    Format   m_swapchain_format;
-    uint32_t m_swapchain_width  = 0;
-    uint32_t m_swapchain_height = 0;
-
     Handle<Pipeline>          m_render_pipeline;
     Handle<DepthStencilState> m_depth_stencil_state;
-    Handle<Texture>           m_depth_texture{0};
     Handle<Texture>           m_color_texture;
     Handle<TextureHeap>       m_texture_heap;
 

--- a/examples/many_cubes/many_cubes.h
+++ b/examples/many_cubes/many_cubes.h
@@ -13,7 +13,7 @@ class ManyCubes : public Example {
     ManyCubes(const WindowState& window_state);
     ~ManyCubes() override;
 
-    bool Update(const UpdateInfo& window) override;
+    bool update(const UpdateInfo& window) override;
 
    private:
     Handle<Pipeline>          m_render_pipeline;

--- a/examples/particle_emitter/particle_emitter.cpp
+++ b/examples/particle_emitter/particle_emitter.cpp
@@ -214,8 +214,8 @@ bool ParticleEmitter::Update(const UpdateInfo& info) {
             .camera =
                 {
                     .projection =
-                        geometry::projection({.view_width  = (float)m_swapchain_width,
-                                              .view_height = (float)m_swapchain_height,
+                        geometry::projection({.view_width  = (float)info.texture_size.x,
+                                              .view_height = (float)info.texture_size.y,
                                               .y_fov       = geometry::radians_from_degrees(30.f),
                                               .depth_far   = 0.5f}),
                     .camera_from_world =
@@ -264,8 +264,8 @@ bool ParticleEmitter::Update(const UpdateInfo& info) {
                                        },
                                    .render_area =
                                        {
-                                           .width  = m_swapchain_width,
-                                           .height = m_swapchain_height,
+                                           .width  = info.texture_size.x,
+                                           .height = info.texture_size.y,
                                        },
                                });
     gpu::cmd_push_debug_group(cmd, "Render particles"_sv);

--- a/examples/particle_emitter/particle_emitter.cpp
+++ b/examples/particle_emitter/particle_emitter.cpp
@@ -172,7 +172,7 @@ ParticleEmitter::~ParticleEmitter() {
     m_ring_buffer = RingBuffer();
 }
 
-bool ParticleEmitter::Update(const UpdateInfo& info) {
+bool ParticleEmitter::update(const UpdateInfo& info) {
     // CPU-side update, construct GPU arguments.
 
     loon::imgui::NewFrame();

--- a/examples/particle_emitter/particle_emitter.cpp
+++ b/examples/particle_emitter/particle_emitter.cpp
@@ -54,23 +54,7 @@ static Format select_surface_format(const loon::gpu::SurfaceCapabilities& surfac
     return surface_capabilities.formats[0];
 }
 
-ParticleEmitter::ParticleEmitter(const WindowState& window_state) {
-    m_device = loon::gpu::create_device({
-        .gpu_preference         = GpuPreference::Discrete,
-        .native_window_handle   = window_state.native_window_handle,
-        .native_instance_handle = window_state.native_instance_handle,
-        .log_callback           = log_callback,
-        .log_userdata           = nullptr,
-        .log_level              = LogLevel::Debug,
-        .alloc_callback         = nullptr,
-        .alloc_userdata         = nullptr,
-    });
-
-    auto surface_capabilities = gpu::get_surface_capabilities(m_device);
-    m_swapchain_format        = select_surface_format(surface_capabilities);
-
-    recreate_swapchain(window_state.width, window_state.height);
-
+ParticleEmitter::ParticleEmitter(const WindowState& window_state) : Example(window_state) {
     // Load shaders and create render pipeline
     ShaderModule shader               = window_state.shader_loader->load_module("particle_emitter");
     const auto   get_compute_pipeline = [&](loon::gpu::Span<const char> name) -> Handle<Pipeline> {
@@ -116,8 +100,6 @@ ParticleEmitter::ParticleEmitter(const WindowState& window_state) {
         });
     assert(m_update_sim_pipeline.h != 0);
     assert(m_render_particle_pipeline.h != 0);
-
-    m_queue = gpu::get_queue(m_device);
 
     m_depth_stencil_state =
         gpu::create_depth_stencil_state(m_device,
@@ -188,46 +170,9 @@ ParticleEmitter::~ParticleEmitter() {
     gpu::device_wait_for_idle(m_device);
     loon::imgui::Shutdown();
     m_ring_buffer = RingBuffer();
-    destroy_device(m_device);
 }
 
-
-void ParticleEmitter::recreate_swapchain(uint32_t width, uint32_t height) {
-    gpu::device_wait_for_idle(m_device);
-    gpu::unconfigure_surface(m_device);
-    gpu::configure_surface(m_device,
-                           {
-                               .format       = m_swapchain_format,
-                               .usages       = loon::gpu::UsageFlags::ColorAttachment,
-                               .width        = width,
-                               .height       = height,
-                               .present_mode = PresentMode::Fifo,
-                           });
-    m_swapchain_width  = width;
-    m_swapchain_height = height;
-
-    // Recreate depth buffer as well
-    if (m_depth_texture) { gpu::free(m_device, m_depth_texture); }
-    m_depth_texture =
-        gpu::create_texture(m_device,
-                            {
-                                .type       = TextureType::Tex2D,
-                                .dimensions = {.x = width, .y = height, .z = 1},
-                                .format     = loon::gpu::Format::Depth32Float,
-                                .usage      = loon::gpu::UsageFlags::DepthStencilAttachment,
-                            });
-}
-
-void ParticleEmitter::Update(const WindowState& window) {
-    auto surface_texture = gpu::get_current_texture(m_device);
-    if (surface_texture.status == SurfaceStatus::OutOfDate ||
-        surface_texture.status == SurfaceStatus::Suboptimal) {
-        recreate_swapchain(window.width, window.height);
-        return;
-    } else if (surface_texture.status == SurfaceStatus::Error) {
-        return;
-    }
-
+bool ParticleEmitter::Update(const UpdateInfo& info) {
     // CPU-side update, construct GPU arguments.
 
     loon::imgui::NewFrame();
@@ -269,8 +214,8 @@ void ParticleEmitter::Update(const WindowState& window) {
             .camera =
                 {
                     .projection =
-                        geometry::projection({.view_width  = (float)window.width,
-                                              .view_height = (float)window.height,
+                        geometry::projection({.view_width  = (float)m_swapchain_width,
+                                              .view_height = (float)m_swapchain_height,
                                               .y_fov       = geometry::radians_from_degrees(30.f),
                                               .depth_far   = 0.5f}),
                     .camera_from_world =
@@ -305,14 +250,14 @@ void ParticleEmitter::Update(const WindowState& window) {
                                {
                                    .color_attachments =
                                        RenderAttachment{
-                                           .texture     = surface_texture.texture,
+                                           .texture     = info.color_texture,
                                            .load_op     = LoadOp::Clear,
                                            .store_op    = StoreOp::Store,
                                            .clear_color = Color(0, 0, 0, 0),
                                        },
                                    .depth_attachment =
                                        RenderAttachment{
-                                           .texture     = m_depth_texture,
+                                           .texture     = info.depth_texture,
                                            .load_op     = LoadOp::Clear,
                                            .store_op    = StoreOp::Discard,
                                            .clear_color = Color(0, 0, 0, 0),
@@ -341,10 +286,7 @@ void ParticleEmitter::Update(const WindowState& window) {
     gpu::cmd_finalize(cmd);
     gpu::queue_submit(m_queue, cmd);
 
-    const auto status = gpu::present(m_device, m_queue);
-    if (status == SurfaceStatus::OutOfDate || status == SurfaceStatus::Suboptimal) {
-        recreate_swapchain(window.width, window.height);
-    }
 
     gpu::queue_process_events(m_queue);
+    return true;
 }

--- a/examples/particle_emitter/particle_emitter.h
+++ b/examples/particle_emitter/particle_emitter.h
@@ -34,7 +34,7 @@ class ParticleEmitter : public Example {
     ~ParticleEmitter() override;
 
    private:
-    bool Update(const UpdateInfo& info) override;
+    bool update(const UpdateInfo& info) override;
 
     Handle<DepthStencilState> m_depth_stencil_state;
     Handle<TextureHeap>       m_texture_heap;

--- a/examples/particle_emitter/particle_emitter.h
+++ b/examples/particle_emitter/particle_emitter.h
@@ -33,19 +33,10 @@ class ParticleEmitter : public Example {
     ParticleEmitter(const WindowState& window_state);
     ~ParticleEmitter() override;
 
-    void Update(const WindowState& window) override;
-
    private:
-    void recreate_swapchain(uint32_t width, uint32_t height);
-
-    Device   m_device;
-    Queue    m_queue;
-    Format   m_swapchain_format;
-    uint32_t m_swapchain_width  = 0;
-    uint32_t m_swapchain_height = 0;
+    bool Update(const UpdateInfo& info) override;
 
     Handle<DepthStencilState> m_depth_stencil_state;
-    Handle<Texture>           m_depth_texture{0};
     Handle<TextureHeap>       m_texture_heap;
 
     Handle<Pipeline> m_reset_sim_pipeline;

--- a/examples/textured_cube/textured_cube.cpp
+++ b/examples/textured_cube/textured_cube.cpp
@@ -81,23 +81,7 @@ static Format select_surface_format(const loon::gpu::SurfaceCapabilities& surfac
     return surface_capabilities.formats[0];
 }
 
-TexturedCube::TexturedCube(const WindowState& window_state) {
-    m_device = loon::gpu::create_device({
-        .gpu_preference         = GpuPreference::Discrete,
-        .native_window_handle   = window_state.native_window_handle,
-        .native_instance_handle = window_state.native_instance_handle,
-        .log_callback           = log_callback,
-        .log_userdata           = nullptr,
-        .log_level              = LogLevel::Debug,
-        .alloc_callback         = nullptr,
-        .alloc_userdata         = nullptr,
-    });
-
-    auto surface_capabilities = gpu::get_surface_capabilities(m_device);
-    m_swapchain_format        = select_surface_format(surface_capabilities);
-
-    recreate_swapchain(window_state.width, window_state.height);
-
+TexturedCube::TexturedCube(const WindowState& window_state) : Example(window_state) {
     // Load shaders and create render pipeline
     ShaderModule shader         = window_state.shader_loader->load_module("textured_cube");
     const auto   vertex_spirv   = get_spirv(shader.get(), "vertex_main");
@@ -119,8 +103,6 @@ TexturedCube::TexturedCube(const WindowState& window_state) {
         });
 
     assert(m_render_pipeline.h != 0);
-
-    m_queue = gpu::get_queue(m_device);
 
     m_vertex_ptr = gpu::malloc(m_device, Cube::kSize, Memory::Gpu);
 
@@ -192,54 +174,17 @@ TexturedCube::TexturedCube(const WindowState& window_state) {
         });
 }
 
-TexturedCube::~TexturedCube() {
-    destroy_device(m_device);
-}
+TexturedCube::~TexturedCube() = default;
 
-void TexturedCube::recreate_swapchain(uint32_t width, uint32_t height) {
-    gpu::device_wait_for_idle(m_device);
-    gpu::unconfigure_surface(m_device);
-    gpu::configure_surface(m_device,
-                           {
-                               .format       = m_swapchain_format,
-                               .usages       = loon::gpu::UsageFlags::ColorAttachment,
-                               .width        = width,
-                               .height       = height,
-                               .present_mode = PresentMode::Fifo,
-                           });
-    m_swapchain_width  = width;
-    m_swapchain_height = height;
-
-    // Recreate depth buffer as well
-    if (m_depth_texture.h) { gpu::free(m_device, m_depth_texture); }
-    m_depth_texture =
-        gpu::create_texture(m_device,
-                            {
-                                .type       = TextureType::Tex2D,
-                                .dimensions = {.x = width, .y = height, .z = 1},
-                                .format     = loon::gpu::Format::Depth32Float,
-                                .usage      = loon::gpu::UsageFlags::DepthStencilAttachment,
-                            });
-}
-
-void TexturedCube::Update(const WindowState& window) {
-    auto surface_texture = gpu::get_current_texture(m_device);
-    if (surface_texture.status == SurfaceStatus::OutOfDate ||
-        surface_texture.status == SurfaceStatus::Suboptimal) {
-        recreate_swapchain(window.width, window.height);
-        return;
-    } else if (surface_texture.status == SurfaceStatus::Error) {
-        return;
-    }
-
+bool TexturedCube::Update(const UpdateInfo& info) {
     // Update constant data
     auto args = reinterpret_cast<ShaderArgs*>(gpu::get_host_pointer(m_device, m_constant_buffer)) +
                 (m_frame_idx % 3);
     *args = ShaderArgs{
         .camera =
             CameraInfo{
-                .projection        = projection({.view_width  = (float)window.width,
-                                                 .view_height = (float)window.height,
+                .projection        = projection({.view_width  = (float)m_swapchain_width,
+                                                 .view_height = (float)m_swapchain_height,
                                                  .y_fov       = radians_from_degrees(30.f),
                                                  .depth_far   = 0.5f}),
                 .camera_from_world = transform3d::identity().translated({0, 0, -5}).to_matrix(),
@@ -271,14 +216,14 @@ void TexturedCube::Update(const WindowState& window) {
         {
             .color_attachments =
                 RenderAttachment{
-                    .texture     = surface_texture.texture,
+                    .texture     = info.color_texture,
                     .load_op     = loon::gpu::LoadOp::Clear,
                     .store_op    = loon::gpu::StoreOp::Store,
                     .clear_color = Color(0, 0, 0, 0),
                 },
             .depth_attachment =
                 RenderAttachment{
-                    .texture     = m_depth_texture,
+                    .texture     = info.depth_texture,
                     .load_op     = loon::gpu::LoadOp::Clear,
                     .store_op    = loon::gpu::StoreOp::Discard,
                     .clear_color = Color(0, 0, 0, 0),
@@ -308,12 +253,6 @@ void TexturedCube::Update(const WindowState& window) {
     gpu::cmd_finalize(cmd);
     gpu::queue_submit(m_queue, cmd);
 
-    const auto status = gpu::present(m_device, m_queue);
-    if (status == SurfaceStatus::OutOfDate || status == SurfaceStatus::Suboptimal) {
-        recreate_swapchain(window.width, window.height);
-    }
-
-    gpu::queue_process_events(m_queue);
-
     m_frame_idx++;
+    return true;
 }

--- a/examples/textured_cube/textured_cube.cpp
+++ b/examples/textured_cube/textured_cube.cpp
@@ -176,7 +176,7 @@ TexturedCube::TexturedCube(const WindowState& window_state) : Example(window_sta
 
 TexturedCube::~TexturedCube() = default;
 
-bool TexturedCube::Update(const UpdateInfo& info) {
+bool TexturedCube::update(const UpdateInfo& info) {
     // Update constant data
     auto args = reinterpret_cast<ShaderArgs*>(gpu::get_host_pointer(m_device, m_constant_buffer)) +
                 (m_frame_idx % 3);

--- a/examples/textured_cube/textured_cube.cpp
+++ b/examples/textured_cube/textured_cube.cpp
@@ -183,8 +183,8 @@ bool TexturedCube::Update(const UpdateInfo& info) {
     *args = ShaderArgs{
         .camera =
             CameraInfo{
-                .projection        = projection({.view_width  = (float)m_swapchain_width,
-                                                 .view_height = (float)m_swapchain_height,
+                .projection        = projection({.view_width  = (float)info.texture_size.x,
+                                                 .view_height = (float)info.texture_size.y,
                                                  .y_fov       = radians_from_degrees(30.f),
                                                  .depth_far   = 0.5f}),
                 .camera_from_world = transform3d::identity().translated({0, 0, -5}).to_matrix(),
@@ -211,25 +211,28 @@ bool TexturedCube::Update(const UpdateInfo& info) {
         cmd,
         StageFlags::FragmentTests,
         StageFlags::FragmentTests);  // We only have one depth buffer so need to stall here.
-    gpu::cmd_begin_render_pass(
-        cmd,
-        {
-            .color_attachments =
-                RenderAttachment{
-                    .texture     = info.color_texture,
-                    .load_op     = loon::gpu::LoadOp::Clear,
-                    .store_op    = loon::gpu::StoreOp::Store,
-                    .clear_color = Color(0, 0, 0, 0),
-                },
-            .depth_attachment =
-                RenderAttachment{
-                    .texture     = info.depth_texture,
-                    .load_op     = loon::gpu::LoadOp::Clear,
-                    .store_op    = loon::gpu::StoreOp::Discard,
-                    .clear_color = Color(0, 0, 0, 0),
-                },
-            .render_area = {.width = m_swapchain_width, .height = m_swapchain_height},
-        });
+    gpu::cmd_begin_render_pass(cmd,
+                               {
+                                   .color_attachments =
+                                       RenderAttachment{
+                                           .texture     = info.color_texture,
+                                           .load_op     = loon::gpu::LoadOp::Clear,
+                                           .store_op    = loon::gpu::StoreOp::Store,
+                                           .clear_color = Color(0, 0, 0, 0),
+                                       },
+                                   .depth_attachment =
+                                       RenderAttachment{
+                                           .texture     = info.depth_texture,
+                                           .load_op     = loon::gpu::LoadOp::Clear,
+                                           .store_op    = loon::gpu::StoreOp::Discard,
+                                           .clear_color = Color(0, 0, 0, 0),
+                                       },
+                                   .render_area =
+                                       {
+                                           .width  = info.texture_size.x,
+                                           .height = info.texture_size.y,
+                                       },
+                               });
 
     gpu::cmd_set_front_face(cmd, FrontFace::CW);
     gpu::cmd_set_cull_mode(cmd, Cull::Back);

--- a/examples/textured_cube/textured_cube.h
+++ b/examples/textured_cube/textured_cube.h
@@ -9,7 +9,7 @@ class TexturedCube : public Example {
    public:
     TexturedCube(const WindowState& window_state);
     ~TexturedCube() override;
-    bool Update(const UpdateInfo& info) override;
+    bool update(const UpdateInfo& info) override;
 
    private:
     static constexpr uint64_t kMaxFramesInFlight = 3;

--- a/examples/textured_cube/textured_cube.h
+++ b/examples/textured_cube/textured_cube.h
@@ -9,24 +9,16 @@ class TexturedCube : public Example {
    public:
     TexturedCube(const WindowState& window_state);
     ~TexturedCube() override;
-    void Update(const WindowState& window) override;
+    bool Update(const UpdateInfo& info) override;
 
    private:
-    void recreate_swapchain(uint32_t width, uint32_t height);
-
     static constexpr uint64_t kMaxFramesInFlight = 3;
-    Device                    m_device;
-    Queue                     m_queue;
-    Format                    m_swapchain_format;
     Handle<Pipeline>          m_render_pipeline;
-    uint64_t                  m_frame_idx        = 0;
-    uint32_t                  m_swapchain_width  = 0;
-    uint32_t                  m_swapchain_height = 0;
+    uint64_t                  m_frame_idx = 0;
 
     GpuPtr m_vertex_ptr;
 
     GpuPtr                    m_constant_buffer;
-    Handle<Texture>           m_depth_texture;
     Handle<DepthStencilState> m_depth_stencil_state;
 
     Handle<TextureHeap> m_texture_heap;


### PR DESCRIPTION
Moves the device creation and swapchain setup into the example.cpp file, instead of the individual example programs. Was getting a bit repetitive and hopefully this doesn't hurt understandability much.